### PR TITLE
Add support for PATCH and DELETE methods in Discord event API

### DIFF
--- a/pages/api/v1/discord/event.ts
+++ b/pages/api/v1/discord/event.ts
@@ -6,7 +6,7 @@ import NextCors from "nextjs-cors";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   await NextCors(req, res, {
-    methods: ["POST"],
+    methods: ["POST", "PATCH", "DELETE"],
     origin: "*",
     optionsSuccessStatus: 200,
   });
@@ -17,8 +17,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.status(400).json({ error: err });
   }
 
-  // Validate body provided
+  // Ensure body exists
   if (!req.body) return res.status(400).json({ error: "No body provided" });
+
+  switch (req.method) {
+    case "POST":
+      return post_handler(req, res);
+    case "PATCH":
+      return patch_handler(req, res);
+    case "DELETE":
+      return delete_handler(req, res);
+    default:
+      return res.status(405).json({ error: "Method not allowed" });
+  }
+}
+
+async function post_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   const { title, start, end, description, location, image } = req.body;
 
   // Validate body values exist and are acceptable
@@ -62,7 +76,48 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       title, location
     );
 
-    return res.status(200).json({ message: "Event created successfully!" });
+    return res.status(200).json({ message: `Event created with ID: ${eventID}` });
+  } catch (err) {
+    return res.status(400).json({ error: JSON.stringify(err) });
+  }
+}
+
+async function patch_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  if (!req.body) return res.status(400).json({ error: "No body provided" });
+  const { eventID, title, start, end, description, location, image } = req.body;
+
+  // Validate body values exist and are acceptable
+  if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
+  if (start && new Date(start) < new Date())
+    return res.status(400).json({ error: "Start date cannot be in the past" });
+  if (start && new Date(end) < new Date())
+    return res.status(400).json({ error: "End date cannot be in the past" });
+
+  try {
+    await discord.editDiscordEvent(eventID, title, start, end, description, location, image);
+    discord.pingDiscordWebhook(
+      ":bangbang: Discord event modified!",
+      `${process.env.ACM_DISCORD_INVITE_URL}?event=${eventID}`,
+      title, location
+    );
+
+    return res.status(200).json({ message: `Event modified with ID: ${eventID}` });
+  } catch (err) {
+    return res.status(400).json({ error: JSON.stringify(err) });
+  }
+}
+
+async function delete_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  const { eventID } = req.body;
+
+  // Validate body values exist and are acceptable
+  if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
+
+  try {
+    await discord.deleteDiscordEvent(eventID);
+    discord.pingDiscordWebhook(":bangbang: Discord event deleted!");
+
+    return res.status(200).json({ message: `Event deleted with ID: ${eventID}` });
   } catch (err) {
     return res.status(400).json({ error: JSON.stringify(err) });
   }

--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -18,7 +18,12 @@ export const imageUrlToBase64 = async (url: string) => {
   return `data:image/${extension};base64,${Buffer.from(blob).toString('base64')}`
 };
 
-export const pingDiscordWebhook = (message: string, url: string, title: string, location: string) => {
+export const pingDiscordWebhook = (message: string, url?: string, title?: string, location?: string) => {
+  let description = "";
+  if (url || title || location) {
+    description = `**Event title**: ${title}\n**Location**: ${location}\n**Link**: ${url}`;
+  }
+  
   const hook = new WebhookClient({
     url: process.env.DISCORD_WEBHOOK_URL as string,
   });
@@ -27,7 +32,7 @@ export const pingDiscordWebhook = (message: string, url: string, title: string, 
     embeds: [
       {
         title: message,
-        description: `**Event title**: ${title}\n**Location**: ${location}\n**Link**: ${url}`,
+        description,
       },
     ],
   });
@@ -57,6 +62,43 @@ export const createDiscordEvent = async (
       privacy_level: 2,
     },
   });
+
+  return response;
+};
+
+export const editDiscordEvent = async (
+  eventID: string,
+  title?: string,
+  start?: string,
+  end?: string,
+  location?: string,
+  description?: string,
+  image?: string
+) => {
+  const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN as string);
+
+  const response = await rest.patch(`/guilds/${process.env.ACM_GUILD_ID}/scheduled-events/${eventID}`, {
+    body: {
+      name: title,
+      scheduled_start_time: start,
+      scheduled_end_time: end,
+      description,
+      image,
+      entity_metadata: {
+        location,
+      },
+      entity_type: 3,
+      privacy_level: 2,
+    },
+  });
+
+  return response;
+};
+
+export const deleteDiscordEvent = async (eventID: string) => {
+  const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_BOT_TOKEN as string);
+
+  const response = await rest.delete(`/guilds/${process.env.ACM_GUILD_ID}/scheduled-events/${eventID}`);
 
   return response;
 };


### PR DESCRIPTION
Added PATCH and DELETE methods to discord event API in klefki.

PATCH is the same format as POST, but with 1 extra field (eventID), and every other field being optional.

DELETE only has 1 field (eventID).

This is what the pings look like:
![image](https://github.com/acmucsd/klefki/assets/5413412/f9bcb09c-e2a8-43d6-8d2b-ad8f5873a192)

Postman requests:
![image](https://github.com/acmucsd/klefki/assets/5413412/61bab868-2903-482d-8a4a-e0b2c2acfa0f)
![image](https://github.com/acmucsd/klefki/assets/5413412/8827ce48-19b1-4859-b9e9-daa5918fb6c4)

