### PR TITLE
added API endpoints for patch/delete for calendar events

### DIFF
--- a/pages/api/v1/calendar/event.ts
+++ b/pages/api/v1/calendar/event.ts
@@ -3,13 +3,25 @@ import { calendar } from "@/util";
 import type { Data } from "@/util/types";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
-  // Validate POST request type
-  if (req.method !== "POST") return res.status(400).json({ error: "Invalid request method" });
-
   // Validate body provided
   if (!req.body) return res.status(400).json({ error: "No body provided" });
-  const { name, start, end, description, location, eventLink } = req.body;
+  
+  // Validate request type
+  switch (req.method) {
+    case "POST":
+      return post_handler(req, res);
+    case "PATCH":
+      return patch_handler(req, res);
+    case "DELETE":
+      return delete_handler(req, res);
+    default:
+      return res.status(405).json({ error: "Invalid request method" });
+  }
+}
 
+async function post_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  const { name, start, end, description, location, eventLink } = req.body;
+  
   // Validate body values exist and are acceptable
   if (!name) return res.status(400).json({ error: "Missing required body field: name" });
   if (!start) return res.status(400).json({ error: "Missing required body field: start" });
@@ -25,10 +37,49 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   // Create Google calendar event
   try {
-    await calendar.createCalendarEvent(name, start, end, location, description, eventLink);
-    return res.status(200).json({ message: "Event created successfully!" });
+    const eventID = await calendar.createCalendarEvent(name, start, end, location, description, eventLink);
+    return res.status(200).json({ message: `Event created with calendar ID: ${eventID}` });
   } catch (err) {
-    console.error(err);
+    return res.status(400).json({ error: JSON.stringify(err) });
+  }
+}
+
+async function patch_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  const { eventID, name, start, end, description, location, eventLink } = req.body;
+  
+  // Validate body values exist and are acceptable
+  if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
+  if (!name) return res.status(400).json({ error: "Missing required body field: name" });
+  if (!start) return res.status(400).json({ error: "Missing required body field: start" });
+  if (!end) return res.status(400).json({ error: "Missing required body field: end" });
+  if (!description)
+    return res.status(400).json({ error: "Missing required body field: description" });
+  if (!location) return res.status(400).json({ error: "Missing required body field: location" });
+  if (!eventLink) return res.status(400).json({ error: "Missing required body field: eventLink" });
+  if (new Date(start) < new Date())
+    return res.status(400).json({ error: "Start date cannot be in the past" });
+  if (new Date(end) < new Date())
+    return res.status(400).json({ error: "End date cannot be in the past" });
+
+  try {
+    await calendar.editCalendarEvent(eventID, name, start, end, location, description, eventLink);
+    return res.status(200).json({ message: `Event modified with ID: ${eventID}` });
+  } catch (err) {
+    return res.status(400).json({ error: JSON.stringify(err) });
+  }
+}
+
+async function delete_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  const { eventID } = req.body;
+
+  // Validate body values exist and are acceptable
+  if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
+
+  try {
+    await calendar.deleteCalendarEvent(eventID);
+
+    return res.status(200).json({ message: `Event deleted with ID: ${eventID}` });
+  } catch (err) {
     return res.status(400).json({ error: JSON.stringify(err) });
   }
 }

--- a/pages/api/v1/calendar/event.ts
+++ b/pages/api/v1/calendar/event.ts
@@ -9,31 +9,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   // Validate request type
   switch (req.method) {
     case "POST":
-      return post_handler(req, res);
+      return createCalendarEvent(req, res);
     case "PATCH":
-      return patch_handler(req, res);
+      return editCalendarEvent(req, res);
     case "DELETE":
-      return delete_handler(req, res);
+      return deleteCalendarEvent(req, res);
     default:
       return res.status(405).json({ error: "Invalid request method" });
   }
 }
 
-async function post_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+async function createCalendarEvent(req: NextApiRequest, res: NextApiResponse<Data>) {
   const { name, start, end, description, location, eventLink } = req.body;
-  
-  // Validate body values exist and are acceptable
-  if (!name) return res.status(400).json({ error: "Missing required body field: name" });
-  if (!start) return res.status(400).json({ error: "Missing required body field: start" });
-  if (!end) return res.status(400).json({ error: "Missing required body field: end" });
-  if (!description)
-    return res.status(400).json({ error: "Missing required body field: description" });
-  if (!location) return res.status(400).json({ error: "Missing required body field: location" });
-  if (!eventLink) return res.status(400).json({ error: "Missing required body field: eventLink" });
-  if (new Date(start) < new Date())
-    return res.status(400).json({ error: "Start date cannot be in the past" });
-  if (new Date(end) < new Date())
-    return res.status(400).json({ error: "End date cannot be in the past" });
+  const validationError = validateBody(res, name, start, end, description, location, eventLink);
+  if (validationError) return res.status(400).json({ error: validationError });
 
   // Create Google calendar event
   try {
@@ -44,23 +33,13 @@ async function post_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   }
 }
 
-async function patch_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+async function editCalendarEvent(req: NextApiRequest, res: NextApiResponse<Data>) {
   const { eventID, name, start, end, description, location, eventLink } = req.body;
-  
-  // Validate body values exist and are acceptable
+  const validationError = validateBody(res, name, start, end, description, location, eventLink);
+  if (validationError) return res.status(400).json({ error: validationError });
   if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
-  if (!name) return res.status(400).json({ error: "Missing required body field: name" });
-  if (!start) return res.status(400).json({ error: "Missing required body field: start" });
-  if (!end) return res.status(400).json({ error: "Missing required body field: end" });
-  if (!description)
-    return res.status(400).json({ error: "Missing required body field: description" });
-  if (!location) return res.status(400).json({ error: "Missing required body field: location" });
-  if (!eventLink) return res.status(400).json({ error: "Missing required body field: eventLink" });
-  if (new Date(start) < new Date())
-    return res.status(400).json({ error: "Start date cannot be in the past" });
-  if (new Date(end) < new Date())
-    return res.status(400).json({ error: "End date cannot be in the past" });
 
+  // Edit Google calendar event
   try {
     await calendar.editCalendarEvent(eventID, name, start, end, location, description, eventLink);
     return res.status(200).json({ message: `Event modified with ID: ${eventID}` });
@@ -69,12 +48,13 @@ async function patch_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   }
 }
 
-async function delete_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+async function deleteCalendarEvent(req: NextApiRequest, res: NextApiResponse<Data>) {
   const { eventID } = req.body;
 
   // Validate body values exist and are acceptable
   if (!eventID) return res.status(400).json({ error: "Missing required body field: eventID" });
 
+  // Delete Google calendar event
   try {
     await calendar.deleteCalendarEvent(eventID);
 
@@ -82,4 +62,21 @@ async function delete_handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   } catch (err) {
     return res.status(400).json({ error: JSON.stringify(err) });
   }
+}
+
+function validateBody(res: NextApiResponse<Data>, name: string, start: string, end: string, description: string, location: string, eventLink: string): string | null {
+  // Validate body values exist and are acceptable
+  if (!name) return "Missing required body field: name";
+  if (!start) return "Missing required body field: start";
+  if (!end) return "Missing required body field: end";
+  if (!description)
+    return "Missing required body field: description";
+  if (!location) return "Missing required body field: location";
+  if (!eventLink) return "Missing required body field: eventLink";
+  if (new Date(start) < new Date())
+    return "Start date cannot be in the past";
+  if (new Date(end) < new Date())
+    return "End date cannot be in the past";
+
+  return null;
 }

--- a/src/util/calendar.ts
+++ b/src/util/calendar.ts
@@ -19,26 +19,67 @@ export async function createCalendarEvent(
   endTime: string,
   location: string,
   description: string,
-  eventLink: string
+  eventLink: string,
+): Promise<string | null | undefined> {
+  const calendar = await initializeCalendar();
+  const eventDescription = `${description}\n\nLocation: ${location}\nEvent Link: ${eventLink}`;
+  
+  const response = await calendar.events.insert({
+    calendarId: process.env.GOOGLE_CALENDAR_ID,
+    requestBody: {
+      summary: title,
+      description: eventDescription,
+      location,
+      start: {
+        dateTime: startTime,
+      },
+      end: {
+        dateTime: endTime,
+      },
+    },
+  });
+  
+  return response?.data?.id;
+}
+
+export async function editCalendarEvent(
+  eventId: string,
+  title: string,
+  startTime: string,
+  endTime: string,
+  location: string,
+  description: string,
+  eventLink: string,
 ): Promise<void> {
   const calendar = await initializeCalendar();
   const eventDescription = `${description}\n\nLocation: ${location}\nEvent Link: ${eventLink}`;
-  try {
-    const response = await calendar.events.insert({
-      calendarId: process.env.GOOGLE_CALENDAR_ID,
-      requestBody: {
-        summary: title,
-        description: eventDescription,
-        location,
-        start: {
-          dateTime: startTime,
-        },
-        end: {
-          dateTime: endTime,
-        },
+  
+  await calendar.events.update({
+    calendarId: process.env.GOOGLE_CALENDAR_ID,
+    eventId,
+    requestBody: {
+      summary: title,
+      description: eventDescription,
+      location,
+      start: {
+        dateTime: startTime,
       },
-    });
-  } catch (err) {
-    console.error(err);
-  }
+      end: {
+        dateTime: endTime,
+      },
+    },
+  });
+}
+
+
+
+export async function deleteCalendarEvent(
+  eventId: string,
+): Promise<void> {
+  const calendar = await initializeCalendar();
+  
+  await calendar.events.delete({
+    calendarId: process.env.GOOGLE_CALENDAR_ID,
+    eventId,
+  });
 }


### PR DESCRIPTION
Added support for PATCH/DELETE requests for calendar events. Postman requests:

POST:
![image](https://github.com/user-attachments/assets/12980b64-e295-45ca-884c-539da470206d)

PATCH:
![image](https://github.com/user-attachments/assets/be217d1e-031e-48ec-af2b-045ef19c609f)

DELETE:
![image](https://github.com/user-attachments/assets/78c01ea9-6ecd-4e7f-80cb-fc255b6e5708)
